### PR TITLE
Add support for site specific assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,9 @@ end
     mix deps.compile
     mix gonz.new MyAwesomeSite
     mix gonz.build
+    mix gonz.serve
 
-Open [build/index.html](build/index.html) in your browser.
+Open [http://localhost:4000/](http://localhost:4000/) in your browser.
 
 ## Goals
 
@@ -73,6 +74,13 @@ Arguments:
 - theme-name: Optional name of the theme to use, defaults to "default"
 - output-directory: Optional name of the build/output directory. Defaults to "./build"
 
+### `gonz.serve` [output-directory]
+
+Serves the built site for local development.
+
+Arguments:
+- output-directory: Optional name of the build/output directory to serve files from. Defaults to "./build"
+
 ### `gonz.purge [output-directory]`
 
 Removes all files related to the site. This can give you a fresh start. Mostly used for manual testing new sites easily.
@@ -83,6 +91,14 @@ Arguments:
 ### Planned tasks
 
 `mix gonz.page title`
+
+### Adding static assets to your site
+
+#### Example: You want to add the image "pangolin.png" to a post
+
+1. Copy pangolin.png to "./assets/images/" (you may have to create the "images" subdir)
+2. In your post file markdown, insert: `![A cool pangolin](./assets/images/pangolin.png)`
+3. Build the site 🎉
 
 ### Themes
 

--- a/lib/gonz/build.ex
+++ b/lib/gonz/build.ex
@@ -35,8 +35,8 @@ defmodule Gonz.Build do
          _ <- File.mkdir_p(pages_output),
          {:ok, post_docs} <- Gonz.Document.load(Gonz.Site.posts_dir(), :posts),
          {:ok, page_docs} <- Gonz.Document.load(Gonz.Site.pages_dir(), :pages),
-         post_navigation <- Gonz.Navigation.content(page_docs, theme, "../"),
-         page_navigation <- Gonz.Navigation.content(page_docs, theme, ""),
+         post_navigation <- Gonz.Navigation.content(page_docs, theme),
+         page_navigation <- Gonz.Navigation.content(page_docs, theme),
          :ok <- write_documents_as_html(posts_output, post_docs, theme, navigation: post_navigation, category: :posts),
          :ok <- write_documents_as_html(pages_output, page_docs, theme, navigation: page_navigation, category: :pages) do
       index(post_docs, theme, page_navigation, output: output)
@@ -58,21 +58,16 @@ defmodule Gonz.Build do
          {:ok, layout_template} <- Gonz.Site.template(theme),
          # This is really awkward..
          asset_dir <- dir |> Path.split() |> Enum.take(2) |> Path.join(),
-         category_asset_prefix <- category_asset_prefix(category),
          layout_assigns <- [
            content: doc_content,
            navigation: navigation,
-           js: Gonz.Build.Asset.js(asset_dir, category_asset_prefix),
-           css: Gonz.Build.Asset.css(asset_dir, category_asset_prefix)
+           js: Gonz.Build.Asset.js(asset_dir),
+           css: Gonz.Build.Asset.css(asset_dir)
          ],
          final_content <- EEx.eval_string(layout_template, assigns: layout_assigns) do
       File.write(dir <> "/#{doc.filename}", final_content)
     end
   end
-
-  def category_asset_prefix(:index), do: ""
-  def category_asset_prefix(:pages), do: ""
-  def category_asset_prefix(:posts), do: "../"
 
   def default_output_dir(), do: "./build"
 

--- a/lib/gonz/build/asset.ex
+++ b/lib/gonz/build/asset.ex
@@ -3,16 +3,21 @@ defmodule Gonz.Build.Asset do
   Static assets for the theme
   """
 
-  def copy(theme, output) do
+  def copy_theme(theme, output) do
     File.mkdir_p("./#{output}/assets")
     File.cp_r("./themes/#{theme}/assets", "./#{output}/assets")
+  end
+
+  def copy_site(output) do
+    File.mkdir_p("./#{output}/assets")
+    File.cp_r("./assets", "./#{output}/assets")
   end
 
   def css_files(output) do
     File.ls!("./#{output}/assets/css")
     |> Enum.filter(fn file -> String.ends_with?(file, [".css"]) end)
     |> Enum.sort()
-    |> Enum.map(&"assets/css/#{&1}")
+    |> Enum.map(&"/assets/css/#{&1}")
     |> Enum.filter(&(!File.dir?("./#{output}/#{&1}")))
   end
 
@@ -20,19 +25,19 @@ defmodule Gonz.Build.Asset do
     File.ls!("./#{output}/assets/js")
     |> Enum.filter(fn file -> String.ends_with?(file, [".js"]) end)
     |> Enum.sort()
-    |> Enum.map(&"assets/js/#{&1}")
+    |> Enum.map(&"/assets/js/#{&1}")
     |> Enum.filter(&(!File.dir?("./#{output}/#{&1}")))
   end
 
-  def css(output, prefix \\ "../") do
+  def css(output) do
     css_files(output)
-    |> Enum.map(&"<link rel=\"stylesheet\" href=\"#{prefix}#{&1}\" />")
+    |> Enum.map(&"<link rel=\"stylesheet\" href=\"#{&1}\" />")
     |> Enum.join("\n")
   end
 
-  def js(output, prefix \\ "../") do
+  def js(output) do
     js_files(output)
-    |> Enum.map(&"<script type=\"text/javascript\" src=\"#{prefix}#{&1}\"></script>")
+    |> Enum.map(&"<script type=\"text/javascript\" src=\"#{&1}\"></script>")
     |> Enum.join("\n")
   end
 end

--- a/lib/gonz/index.ex
+++ b/lib/gonz/index.ex
@@ -17,8 +17,8 @@ defmodule Gonz.Index do
          layout_assigns <- [
            content: index_content,
            navigation: navigation,
-           js: Gonz.Build.Asset.js(index_dir, ""),
-           css: Gonz.Build.Asset.css(index_dir, "")
+           js: Gonz.Build.Asset.js(index_dir),
+           css: Gonz.Build.Asset.css(index_dir)
          ],
          final_content <- EEx.eval_string(layout_template, assigns: layout_assigns) do
       File.write("#{index_dir}/#{file_name(index_page_nr)}", final_content)

--- a/lib/gonz/navigation.ex
+++ b/lib/gonz/navigation.ex
@@ -17,18 +17,19 @@ defmodule Gonz.Navigation do
     end)
   end
 
-  def content(candidate_docs, theme, href_prefix, opts \\ [])
-  def content([], _, _, _), do: ""
+  def content(candidate_docs, theme, opts \\ [])
+  def content([], _, _), do: ""
 
-  def content(candidate_docs, theme, href_prefix, opts) do
+  def content(candidate_docs, theme, opts) do
     candidate_docs
     |> docs(opts)
-    |> content_for(theme, href_prefix)
+    |> content_for(theme)
   end
 
-  def content_for(nav_docs, theme, href_prefix) do
+  def content_for(nav_docs, theme) do
+    # TODO: remove href_prefix completely from these assigns.
     with {:ok, nav_template} <- template(theme),
-         assigns <- [items: nav_docs, href_prefix: href_prefix] do
+         assigns <- [items: nav_docs, href_prefix: "/"] do
       EEx.eval_string(nav_template, assigns: assigns)
     end
   end

--- a/lib/gonz/plug/site.ex
+++ b/lib/gonz/plug/site.ex
@@ -1,0 +1,51 @@
+defmodule Gonz.Plug.Site do
+  @moduledoc """
+  Serve the site from the build dir.
+  We only need plug and cowboy because we need to be able to browse the site when developing it.
+  """
+  @behaviour Plug
+
+  require Logger
+
+  @static_at "/"
+  @static_base_config Plug.Static.init(at: @static_at, from: Gonz.Build.default_output_dir())
+
+  def init(opts), do: opts
+
+  # Serve the index file from build dir if / is accessed
+  def call(%Plug.Conn{path_info: [], state: state} = conn, opts) when state in [:unset, :set] do
+    build_dir = Keyword.get(opts, :build_dir, Gonz.Build.default_output_dir())
+    path = Path.expand("#{build_dir}/index.html")
+
+    if File.exists?(path) do
+      conn
+      |> Plug.Conn.send_file(200, path)
+      |> Plug.Conn.halt()
+    else
+      Logger.error("index.html not found in directory \"#{build_dir}\". Build the site with: mix gonz.build")
+      not_found(conn)
+    end
+  end
+
+  # Try to serve static content from the build dir.
+  def call(conn, opts) do
+    build_dir = Keyword.get(opts, :build_dir, Gonz.Build.default_output_dir())
+    static_cfg = Map.put(@static_base_config, :from, build_dir)
+
+    conn
+    |> Plug.Static.call(static_cfg)
+    |> not_found()
+  end
+
+  def not_found(%Plug.Conn{state: :unset} = conn) do
+    Logger.debug("Could not find #{inspect(conn.request_path)} - responding with 404")
+
+    Plug.Conn.send_resp(
+      conn,
+      404,
+      "Resource not found. Build your site with: mix gonz.build and then go to http://localhost:4000/"
+    )
+  end
+
+  def not_found(conn), do: conn
+end

--- a/lib/gonz/site.ex
+++ b/lib/gonz/site.ex
@@ -62,15 +62,16 @@ defmodule Gonz.Site do
   end
 
   defp create_content_dirs() do
-    content_dirs = [posts_dir(), drafts_dir(), pages_dir()]
+    content_dirs = [posts_dir(), drafts_dir(), pages_dir(), site_assets_dir()]
     IO.puts("Creating content directories: #{inspect(content_dirs)}")
+    result = Enum.map(content_dirs, &File.mkdir/1)
 
-    case Enum.map(content_dirs, &File.mkdir/1) do
-      [:ok, :ok, :ok] ->
+    case Enum.all?(result, &(&1 == :ok)) do
+      true ->
         :ok
 
-      not_ok ->
-        errors = Enum.reject(not_ok, fn return_val -> return_val == :ok end)
+      false ->
+        errors = Enum.reject(result, &(&1 == :ok))
         {:error, errors}
     end
   end
@@ -89,6 +90,7 @@ defmodule Gonz.Site do
   def drafts_dir(), do: "./drafts"
   def pages_dir(), do: "./pages"
   def themes_dir(), do: "./themes"
+  def site_assets_dir(), do: "./assets"
 
   def filename_from_title("pages", title), do: "#{pages_dir()}/#{sanitize_title(title)}.md"
 

--- a/lib/mix/tasks/gonz/build.ex
+++ b/lib/mix/tasks/gonz/build.ex
@@ -14,12 +14,13 @@ defmodule Mix.Tasks.Gonz.Build do
 
     {microseconds, _} =
       :timer.tc(fn ->
-        Gonz.Build.Asset.copy(theme_name, output)
+        Gonz.Build.Asset.copy_theme(theme_name, output)
+        Gonz.Build.Asset.copy_site(output)
         Gonz.Build.site(theme_name, output)
       end)
 
     IO.puts("Build done, took: #{microseconds * 0.000001}s")
-    IO.puts("Open #{output}/index.html in a browser to see your site")
+    IO.puts("Baked files in \"#{output}\" can now be served by: mix gonz.serve #{output}")
 
     :ok
   end

--- a/lib/mix/tasks/gonz/purge.ex
+++ b/lib/mix/tasks/gonz/purge.ex
@@ -14,6 +14,7 @@ defmodule Mix.Tasks.Gonz.Purge do
       Gonz.Site.posts_dir(),
       Gonz.Site.pages_dir(),
       Gonz.Site.themes_dir(),
+      Gonz.Site.site_assets_dir(),
       output
     ]
 
@@ -26,6 +27,7 @@ defmodule Mix.Tasks.Gonz.Purge do
         Enum.each(known_stuff, &File.rm_rf/1)
 
       _other ->
+        IO.puts("Skipping purge")
         :ok
     end
   end

--- a/lib/mix/tasks/gonz/serve.ex
+++ b/lib/mix/tasks/gonz/serve.ex
@@ -1,0 +1,17 @@
+defmodule Mix.Tasks.Gonz.Serve do
+  @moduledoc """
+  Starts a local web server to serve the built site
+  """
+
+  def run([]), do: run(["build"])
+
+  def run([build_dir]) do
+    Application.start(:cowboy)
+    Application.start(:plug)
+    IO.puts("Starting web server. Site at http://localhost:4000/ serving files from dir: #{build_dir}")
+
+    {:ok, _} = Plug.Adapters.Cowboy2.http(Gonz.Plug.Site, build_dir: build_dir)
+
+    :timer.sleep(:infinity)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -24,6 +24,9 @@ defmodule Gonz.MixProject do
       # convert markdown to html
       {:earmark, "~> 1.2"},
 
+      {:plug, "~> 1.6"},
+      {:cowboy, "~> 2.4"},
+
       # Needed because elixir 1.6
       {:ex_doc, "~> 0.18.0", only: :dev}
     ]

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,12 @@
 %{
+  "cowboy": {:hex, :cowboy, "2.4.0", "f1b72fabe9c8a5fc64ac5ac85fb65474d64733d1df52a26fad5d4ba3d9f70a9f", [:rebar3], [{:cowlib, "~> 2.3.0", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.5.0", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
+  "cowlib": {:hex, :cowlib, "2.3.0", "bbd58ef537904e4f7c1dd62e6aa8bc831c8183ce4efa9bd1150164fe15be4caa", [:rebar3], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.5", "4d21980d5d2862a2e13ec3c49ad9ad783ffc7ca5769cf6ff891a4553fbaae761", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.18.4", "4406b8891cecf1352f49975c6d554e62e4341ceb41b9338949077b0d4a97b949", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup": {:hex, :makeup, "0.5.1", "966c5c2296da272d42f1de178c1d135e432662eca795d6dc12e5e8787514edf7", [], [{:nimble_parsec, "~> 0.2.2", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.8.0", "1204a2f5b4f181775a0e456154830524cf2207cf4f9112215c05e0b76e4eca8b", [], [{:makeup, "~> 0.5.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 0.2.2", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
+  "mime": {:hex, :mime, "1.3.0", "5e8d45a39e95c650900d03f897fbf99ae04f60ab1daa4a34c7a20a5151b7a5fe", [:mix], [], "hexpm"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.2.2", "d526b23bdceb04c7ad15b33c57c4526bf5f50aaa70c7c141b4b4624555c68259", [], [], "hexpm"},
+  "plug": {:hex, :plug, "1.6.3", "43088304337b9e8b8bd22a0383ca2f633519697e4c11889285538148f42cbc5e", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1 or ~> 2.4", [hex: :cowboy, repo: "hexpm", optional: true]}, {:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}], "hexpm"},
+  "ranch": {:hex, :ranch, "1.5.0", "f04166f456790fee2ac1aa05a02745cc75783c2bfb26d39faf6aefc9a3d3a58a", [:rebar3], [], "hexpm"},
 }

--- a/test/plug/site_test.exs
+++ b/test/plug/site_test.exs
@@ -1,0 +1,24 @@
+defmodule Gonz.Plug.SiteTest do
+  use ExUnit.Case, async: true
+  use Plug.Test
+
+  alias Gonz.Plug.Site
+
+  test "returns 404 for missing index file" do
+    conn = conn(:get, "/")
+
+    conn = Site.call(conn, build_dir: "this_should_not_exist")
+
+    assert conn.state == :sent
+    assert conn.status == 404
+  end
+
+  test "return static file that exist" do
+    conn = conn(:get, "mix.exs")
+
+    conn = Site.call(conn, build_dir: "./")
+
+    assert conn.state == :file
+    assert conn.status == 200
+  end
+end


### PR DESCRIPTION
Here we are. In an attempt to fix #13 there is now
a new task: `gonz.serve` which will serve the built
static site. The reason we need this now is because
the simplest way to refer to an asset is by using a
non-relative path, like /assets/images/pangolin.png.
Now browsing the site locally that will not work so we
need to add a web server which will map "/" to whatever
we chose. Oh well.

This change did bring some simplifications to other parts.
However you will still not be able to just render the markdown
and see an image for example, because again the path will
start at the root.