### PR TITLE
Set meta in layout assigns containing front matter

### DIFF
--- a/lib/gonz/bootstrap.ex
+++ b/lib/gonz/bootstrap.ex
@@ -43,6 +43,7 @@ defmodule Gonz.Bootstrap do
         <title>#{name}</title>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
         <meta name="generator" content="Gonz" />
+        <meta name="Description" content="<%= @meta.description %>">
 
         <!-- Thanks to https://webbkoll.dataskydd.net/ -->
         <meta name="referrer" content="no-referrer" /> <!-- Referrer Policy -->

--- a/lib/gonz/build.ex
+++ b/lib/gonz/build.ex
@@ -58,12 +58,7 @@ defmodule Gonz.Build do
          {:ok, layout_template} <- Gonz.Site.template(theme),
          # This is really awkward..
          asset_dir <- dir |> Path.split() |> Enum.take(2) |> Path.join(),
-         layout_assigns <- [
-           content: doc_content,
-           navigation: navigation,
-           js: Gonz.Build.Asset.js(asset_dir),
-           css: Gonz.Build.Asset.css(asset_dir)
-         ],
+         layout_assigns <- Gonz.Layout.assigns(doc_assigns[:front_matter], doc_content, navigation, asset_dir),
          final_content <- EEx.eval_string(layout_template, assigns: layout_assigns) do
       File.write(dir <> "/#{doc.filename}", final_content)
     end

--- a/lib/gonz/index.ex
+++ b/lib/gonz/index.ex
@@ -3,6 +3,9 @@ defmodule Gonz.Index do
   Index page(s)
   """
 
+  alias Gonz.Layout
+  alias Gonz.Markdown.FrontMatter
+
   def create_html({posts, index_page_nr}, index_dir, theme, opts) do
     navigation = Keyword.get(opts, :navigation, "")
     last_page? = Keyword.get(opts, :last_page, false)
@@ -14,12 +17,7 @@ defmodule Gonz.Index do
     with {:ok, index_template} <- template(theme),
          index_content <- EEx.eval_string(index_template, assigns: index_assigns),
          {:ok, layout_template} <- Gonz.Site.template(theme),
-         layout_assigns <- [
-           content: index_content,
-           navigation: navigation,
-           js: Gonz.Build.Asset.js(index_dir),
-           css: Gonz.Build.Asset.css(index_dir)
-         ],
+         layout_assigns <- Layout.assigns(%FrontMatter{}, index_content, navigation, index_dir),
          final_content <- EEx.eval_string(layout_template, assigns: layout_assigns) do
       File.write("#{index_dir}/#{file_name(index_page_nr)}", final_content)
     end

--- a/lib/gonz/layout.ex
+++ b/lib/gonz/layout.ex
@@ -1,0 +1,13 @@
+defmodule Gonz.Layout do
+  alias Gonz.Markdown.FrontMatter
+
+  def assigns(%FrontMatter{} = front_matter, content, navigation, asset_dir) do
+    [
+      meta: front_matter,
+      content: content,
+      navigation: navigation,
+      js: Gonz.Build.Asset.js(asset_dir),
+      css: Gonz.Build.Asset.css(asset_dir)
+    ]
+  end
+end

--- a/lib/mix/tasks/gonz/serve.ex
+++ b/lib/mix/tasks/gonz/serve.ex
@@ -11,7 +11,7 @@ defmodule Mix.Tasks.Gonz.Serve do
     Application.start(:plug)
     IO.puts("Starting web server. Site at http://localhost:#{port}/ serving files from dir: #{build_dir}")
 
-    {:ok, _} = Plug.Adapters.Cowboy2.http(Gonz.Plug.Site, [build_dir: build_dir], [port: port])
+    {:ok, _} = Plug.Adapters.Cowboy2.http(Gonz.Plug.Site, [build_dir: build_dir], port: port)
 
     :timer.sleep(:infinity)
   end


### PR DESCRIPTION
This enables themes to for example add tags like:
`<meta name="Description" content="<%= @meta.description %>">`

The default/bootstrap theme contains this for example.

Fixes #16