### PR TITLE
Replace nav_item with categories concept

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: elixir
 elixir:
-  - 1.6
+  - 1.9
 script:
   - mix test

--- a/README.md
+++ b/README.md
@@ -43,8 +43,9 @@ Some things I've had in mind while hacking on gonz:
 
 - Write pages and posts in Markdown
 - "Themes" with EEx templates
-- A page can be marked as a navigation item, which can be handled in the templates
 - Front matter is specified as an elixir map
+- You can put categories on pages/posts, then themes can handle them in whatever way they wish.
+- There is a special category `:nav_item` that will enable themes to handle some pages as navigation items.
 
 ## Mix tasks
 

--- a/lib/gonz/bootstrap.ex
+++ b/lib/gonz/bootstrap.ex
@@ -84,7 +84,7 @@ defmodule Gonz.Bootstrap do
       <%= Enum.map @posts, fn post ->
         \"\"\"
         <article class="h-entry">
-          <h2 class="p-name"><a href="#\{post.category}/#\{post.filename}">#\{post.markdown.front_matter.title}</a></h2>
+          <h2 class="p-name"><a href="#\{post.type}/#\{post.filename}">#\{post.markdown.front_matter.title}</a></h2>
             <div class="e-content">
               #\{post.html_content}
             </div>
@@ -113,8 +113,8 @@ defmodule Gonz.Bootstrap do
     <nav>
       <ul>
       <%= Enum.map(@items, fn item ->
-        url = if item.category == :posts do
-          "#\{@href_prefix}#\{item.category}/#\{item.filename}"
+        url = if item.type == :posts do
+          "#\{@href_prefix}#\{item.type}/#\{item.filename}"
         else
           "#\{@href_prefix}#\{item.filename}"
         end

--- a/lib/gonz/bootstrap.ex
+++ b/lib/gonz/bootstrap.ex
@@ -27,7 +27,7 @@ defmodule Gonz.Bootstrap do
       There is also code snippet support, and most other things you expect:
 
       ```elixir
-      Gonz.Post.create("Mypage", nav_item?: true, content: "Yo!")
+      Gonz.Post.create("Mypage", categories: [:nav_item, :foo, "bar"], content: "Yo!")
       ```
 
       ![The Gonz](https://media.giphy.com/media/gqG3dwMXRBaBq/giphy.gif)

--- a/lib/gonz/build.ex
+++ b/lib/gonz/build.ex
@@ -37,8 +37,8 @@ defmodule Gonz.Build do
          {:ok, page_docs} <- Gonz.Document.load(Gonz.Site.pages_dir(), :pages),
          post_navigation <- Gonz.Navigation.content(page_docs, theme),
          page_navigation <- Gonz.Navigation.content(page_docs, theme),
-         :ok <- write_documents_as_html(posts_output, post_docs, theme, navigation: post_navigation, category: :posts),
-         :ok <- write_documents_as_html(pages_output, page_docs, theme, navigation: page_navigation, category: :pages) do
+         :ok <- write_documents_as_html(posts_output, post_docs, theme, navigation: post_navigation, type: :posts),
+         :ok <- write_documents_as_html(pages_output, page_docs, theme, navigation: page_navigation, type: :pages) do
       index(post_docs, theme, page_navigation, output: output)
     end
   end
@@ -51,10 +51,10 @@ defmodule Gonz.Build do
 
   def write_document_as_html(dir, %Gonz.Document{} = doc, theme, opts \\ []) do
     navigation = Keyword.get(opts, :navigation, "")
-    category = Keyword.get(opts, :category, :pages)
+    type = Keyword.get(opts, :type, :pages)
 
     with doc_assigns <- Gonz.Document.to_assigns(doc),
-         {:ok, doc_content} <- category_content(theme, category, assigns: doc_assigns),
+         {:ok, doc_content} <- type_content(theme, type, assigns: doc_assigns),
          {:ok, layout_template} <- Gonz.Site.template(theme),
          # This is really awkward..
          asset_dir <- dir |> Path.split() |> Enum.take(2) |> Path.join(),
@@ -66,7 +66,7 @@ defmodule Gonz.Build do
 
   def default_output_dir(), do: "./build"
 
-  def category_content(theme, :pages, opts) do
+  def type_content(theme, :pages, opts) do
     case Gonz.Page.template(theme) do
       {:ok, page_template} ->
         {:ok, EEx.eval_string(page_template, opts)}
@@ -76,7 +76,7 @@ defmodule Gonz.Build do
     end
   end
 
-  def category_content(theme, :posts, opts) do
+  def type_content(theme, :posts, opts) do
     case Gonz.Post.template(theme) do
       {:ok, post_template} ->
         {:ok, EEx.eval_string(post_template, opts)}

--- a/lib/gonz/document.ex
+++ b/lib/gonz/document.ex
@@ -7,26 +7,26 @@ defmodule Gonz.Document do
   defstruct markdown: %Gonz.Markdown{},
             html_content: "",
             filename: "",
-            category: :unknown
+            type: :unknown
 
-  def load(dir, category) do
+  def load(dir, type) do
     with {:ok, files} <- File.ls(dir),
          {:ok, markdowns} <- Gonz.Markdown.parse(files, dir) do
-      from_markdown_files(markdowns, category)
+      from_markdown_files(markdowns, type)
     end
   end
 
-  def from_markdown_files(md_files, category) when is_list(md_files) do
-    result = Enum.map(md_files, fn md_file -> from_markdown_file(md_file, category) end)
+  def from_markdown_files(md_files, type) when is_list(md_files) do
+    result = Enum.map(md_files, fn md_file -> from_markdown_file(md_file, type) end)
     {:ok, result}
   end
 
-  def from_markdown_file(%Gonz.Markdown{} = md_file, category) do
+  def from_markdown_file(%Gonz.Markdown{} = md_file, type) do
     %__MODULE__{
       markdown: md_file,
       html_content: Earmark.as_html!(md_file.content),
-      filename: html_filename(md_file, category),
-      category: category
+      filename: html_filename(md_file, type),
+      type: type
     }
   end
 
@@ -47,7 +47,7 @@ defmodule Gonz.Document do
     Gonz.Site.sanitize_title(md_file.front_matter.title) <> ".html"
   end
 
-  def valid_categories(), do: [:pages, :posts, :drafts, :index]
+  def valid_types(), do: [:pages, :posts, :drafts, :index]
 
   @doc "This determines the available variables in the pages and post theme templates"
   def to_assigns(%__MODULE__{} = doc, content_dir \\ "") do

--- a/lib/gonz/front_matter.ex
+++ b/lib/gonz/front_matter.ex
@@ -1,20 +1,26 @@
 defmodule Gonz.Markdown.FrontMatter do
   @moduledoc """
   This is metadata in the posts/pages markdown, before the actual content.
+
+  - title: The title of the page or post
+  - description: Description
+  - created_at: ISO8601 date time of when the page/post was created
+  - categories: A list of categories the page/post belongs to, these can be anything and themes can do whatever they like with the information.
   """
 
   defstruct title: "",
             description: "",
             created_at: nil,
+            categories: [],
             nav_item: false
 
   def parse(front_matter) when is_binary(front_matter) do
     with {map, _} <- Code.eval_string(front_matter) do
-      # with {:ok, map} <- YamlElixir.read_from_string(front_matter) do
       %__MODULE__{
         title: map.title,
         description: Map.get(map, :description, ""),
         created_at: map.created_at,
+        categories: Map.get(map, :categories, []),
         nav_item: Map.get(map, :nav_item, false)
       }
     end

--- a/lib/gonz/front_matter.ex
+++ b/lib/gonz/front_matter.ex
@@ -11,8 +11,7 @@ defmodule Gonz.Markdown.FrontMatter do
   defstruct title: "",
             description: "",
             created_at: nil,
-            categories: [],
-            nav_item: false
+            categories: []
 
   def parse(front_matter) when is_binary(front_matter) do
     with {map, _} <- Code.eval_string(front_matter) do
@@ -20,8 +19,7 @@ defmodule Gonz.Markdown.FrontMatter do
         title: map.title,
         description: Map.get(map, :description, ""),
         created_at: map.created_at,
-        categories: Map.get(map, :categories, []),
-        nav_item: Map.get(map, :nav_item, false)
+        categories: Map.get(map, :categories, [])
       }
     end
   end

--- a/lib/gonz/navigation.ex
+++ b/lib/gonz/navigation.ex
@@ -37,7 +37,7 @@ defmodule Gonz.Navigation do
   def index_doc() do
     %Gonz.Document{
       filename: "index.html",
-      category: :index,
+      type: :index,
       markdown: %Gonz.Markdown{
         front_matter: %Gonz.Markdown.FrontMatter{
           title: "Home",

--- a/lib/gonz/navigation.ex
+++ b/lib/gonz/navigation.ex
@@ -11,7 +11,7 @@ defmodule Gonz.Navigation do
     extra_docs = if include_index, do: [index_doc()], else: []
 
     (extra_docs ++ candidate_docs)
-    |> Enum.filter(fn doc -> doc.markdown.front_matter.nav_item == true end)
+    |> Enum.filter(fn doc -> Enum.member?(doc.markdown.front_matter.categories, :nav_item) end)
     |> Enum.sort(fn a, b ->
       a.filename >= b.filename
     end)
@@ -41,7 +41,7 @@ defmodule Gonz.Navigation do
       markdown: %Gonz.Markdown{
         front_matter: %Gonz.Markdown.FrontMatter{
           title: "Home",
-          nav_item: true
+          categories: [:home, :nav_item]
         }
       }
     }

--- a/lib/gonz/page.ex
+++ b/lib/gonz/page.ex
@@ -10,17 +10,17 @@ defmodule Gonz.Page do
   end
 
   def new(title, opts) do
-    nav_item = Keyword.get(opts, :nav_item?, false)
     description = Keyword.get(opts, :description, "A dull page")
     content = Keyword.get(opts, :content, "This is the #{title} page")
     created_at = Keyword.get(opts, :created_at, Gonz.now_iso8601())
+    categories = Keyword.get(opts, :categories, [])
 
     """
     ---
     %{
       title: "#{title}",
       description: "#{description}",
-      nav_item: #{nav_item},
+      categories: #{inspect(categories)},
       created_at: "#{created_at}"
     }
     ---

--- a/lib/gonz/site.ex
+++ b/lib/gonz/site.ex
@@ -8,7 +8,12 @@ defmodule Gonz.Site do
     with :ok <- create_default_theme(name),
          :ok <- create_content_dirs(),
          :ok <- Gonz.Page.create("Hello"),
-         :ok <- Gonz.Page.create("About", nav_item?: true, content: "Link to non nav page: [hello](hello.html)"),
+         :ok <-
+           Gonz.Page.create(
+             "About",
+             categories: [:nav_item, :about],
+             content: "Link to non nav page: [hello](hello.html)"
+           ),
          :ok <- Gonz.Bootstrap.example_post(name),
          :ok <- Gonz.Post.create("My older post", created_at: "2018-08-18T09:48:34.117782Z") do
       update_gitignore()

--- a/mix.exs
+++ b/mix.exs
@@ -4,8 +4,8 @@ defmodule Gonz.MixProject do
   def project do
     [
       app: :gonz,
-      version: "2.2.0",
-      elixir: "~> 1.6",
+      version: "3.0.0",
+      elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       description: description(),

--- a/test/front_matter_test.exs
+++ b/test/front_matter_test.exs
@@ -7,13 +7,17 @@ defmodule Gonz.FrontMatterTest do
     test "string to elixir map" do
       created_at = "2018-08-09T17:51:32.905935Z"
       title = "Hellö there"
-      front_matter_string = "%{\n  title: \"#{title}\",\n  created_at: \"#{created_at}\",\n  id: 1\n}"
+      categories = "[:nav_item, \"foo\"]"
+
+      front_matter_string =
+        "%{\n  title: \"#{title}\",\n  created_at: \"#{created_at}\",\n  id: 1,\n categories: #{categories}}"
 
       assert FrontMatter.parse(front_matter_string) == %Gonz.Markdown.FrontMatter{
                created_at: created_at,
                description: "",
                nav_item: false,
-               title: title
+               title: title,
+               categories: [:nav_item, "foo"]
              }
     end
   end

--- a/test/front_matter_test.exs
+++ b/test/front_matter_test.exs
@@ -15,7 +15,6 @@ defmodule Gonz.FrontMatterTest do
       assert FrontMatter.parse(front_matter_string) == %Gonz.Markdown.FrontMatter{
                created_at: created_at,
                description: "",
-               nav_item: false,
                title: title,
                categories: [:nav_item, "foo"]
              }

--- a/test/page_test.exs
+++ b/test/page_test.exs
@@ -11,7 +11,7 @@ defmodule Gonz.PageTest do
       assert %Gonz.Markdown{
                content: "This is the Böring page\n",
                front_matter: %Gonz.Markdown.FrontMatter{
-                 nav_item: false,
+                 categories: [],
                  title: ^title
                }
              } = Gonz.Markdown.parse(new_page)


### PR DESCRIPTION
Fixes #24 
A document (page or post), must now be marked as a navigation item by using the `categories` list in the front matter instead of the removed `nav_item` boolean.