### PR TITLE
Add posts-per-page option for gonz.build

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,15 @@
 
 > I can write anything and just put it in a zine, and then it's out there. It is like blogging but on paper. It is what I started to do before the computers were all popular.
 
-Static site generator. **Heavily** inspired by Obelisk (thanks for a great project!).
+Static site generator. **Heavily** inspired by [Obelisk](https://github.com/BennyHallett/obelisk) (thanks for a great project!).
 
 ## Quick start
 
+Start a new elixir project:
+
 `mix new mysite`
+
+Add gonz dependency:
 
 ```elixir
 defp deps do
@@ -20,6 +24,8 @@ defp deps do
 end
 ```
 
+Use gonz to scaffold your site skeleton:
+
     mix deps.get
     mix deps.compile
     mix gonz.new MyAwesomeSite
@@ -27,6 +33,8 @@ end
     mix gonz.serve
 
 Open [http://localhost:4000/](http://localhost:4000/) in your browser.
+
+Now you probably want to start editing the default theme (or create a new one). See [my own personal site](https://github.com/vorce/forvillelser/tree/master/themes/forvillelser) for an example.
 
 ## Goals
 
@@ -142,7 +150,7 @@ I looked closer at the github page and noticed that the project was a bit abando
 ## Todo
 
 - What about drafts..
-- Rethink code structure, can simplify a lot of things and make it more consistent I think.
+- Rethink code structure, can simplify a lot of things and make it more consistent I think. The clarity bullet in the goals section is not quite there yet :)
 - Low hanging speed ups (Task.async?)
 - Assets. Right now it's all or nothing. What if I want to publish a separate page that needs some assets that nothing else needs?
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Static site generator. **Heavily** inspired by Obelisk (thanks for a great proje
 ```elixir
 defp deps do
   [
-    {:gonz, "~> 3.0"}
+    {:gonz, "~> 3.1"}
   ]
 end
 ```
@@ -67,13 +67,14 @@ Example: `mix gonz.post "My amazing post about Things"`
 Arguments:
 - post-title: Required title of the post
 
-### `gonz.build [theme-name] [output-directory]`
+### `gonz.build [theme-name] [output-directory] [posts-per-page]`
 
 Builds the site.
 
 Arguments:
 - theme-name: Optional name of the theme to use, defaults to "default"
 - output-directory: Optional name of the build/output directory. Defaults to "./build"
+- posts-per-page: Optional number of pages per index page. Defaults to 10.
 
 ### `gonz.serve` [output-directory] [port]
 
@@ -110,7 +111,7 @@ The exact API for themes are subject to change. The available data for the theme
 
 #### Building your site with a non-default theme
 
-**If you use a custom theme, don't forget to specify the name of it when you build your site, ex: `mix gonz.build mythemename build`**
+**If you use a custom theme, don't forget to specify the name of it when you build your site, ex: `mix gonz.build mythemename build 10`**
 
 If this gets repetitive I suggest you create a target in a Makefile.
 

--- a/lib/gonz/build.ex
+++ b/lib/gonz/build.ex
@@ -27,7 +27,7 @@ defmodule Gonz.Build do
   end
 
   @doc "Builds the static site html files from markdown files"
-  def site(theme, output) do
+  def site(theme, output, opts \\ []) do
     posts_output = posts_build_dir(output)
     pages_output = pages_build_dir(output)
 
@@ -39,7 +39,7 @@ defmodule Gonz.Build do
          page_navigation <- Gonz.Navigation.content(page_docs, theme),
          :ok <- write_documents_as_html(posts_output, post_docs, theme, navigation: post_navigation, type: :posts),
          :ok <- write_documents_as_html(pages_output, page_docs, theme, navigation: page_navigation, type: :pages) do
-      index(post_docs, theme, page_navigation, output: output)
+      index(post_docs, theme, page_navigation, Keyword.merge(opts, output: output))
     end
   end
 

--- a/lib/mix/tasks/gonz/build.ex
+++ b/lib/mix/tasks/gonz/build.ex
@@ -6,17 +6,28 @@ defmodule Mix.Tasks.Gonz.Build do
 
   @shortdoc "Build your gonz site"
 
-  def run([]), do: run(["default", Gonz.Build.default_output_dir()])
+  @default_theme_name "default"
+  @default_posts_per_page "10"
 
-  def run([theme_name, output]) do
-    IO.puts("Building site with theme: #{theme_name} into output directory: #{output}")
+  def run([]), do: run([@default_theme_name, Gonz.Build.default_output_dir(), @default_posts_per_page])
+
+  def run([theme_name]), do: run([theme_name, Gonz.Build.default_output_dir(), @default_posts_per_page])
+
+  def run([theme_name, output]), do: run([theme_name, output, @default_posts_per_page])
+
+  def run([theme_name, output, posts_per_page_input]) do
+    posts_per_page = String.to_integer(posts_per_page_input)
+    settings = [theme_name: theme_name, output_dir: output, posts_per_page: posts_per_page]
+
+    IO.puts("Building site with settings: #{inspect(settings)}...")
+
     Application.ensure_all_started(:yaml_elixir)
 
     {microseconds, _} =
       :timer.tc(fn ->
         Gonz.Build.Asset.copy_theme(theme_name, output)
         Gonz.Build.Asset.copy_site(output)
-        Gonz.Build.site(theme_name, output)
+        Gonz.Build.site(theme_name, output, posts_per_page: posts_per_page)
       end)
 
     IO.puts("Build done, took: #{microseconds * 0.000001}s")
@@ -26,6 +37,6 @@ defmodule Mix.Tasks.Gonz.Build do
   end
 
   def run(_) do
-    IO.puts(:stderr, "Expected no arguments or two (theme name, output directory) to this task")
+    IO.puts(:stderr, "Expected zero or 3 arguments (theme name, output directory, posts_per_page) to this task")
   end
 end

--- a/lib/mix/tasks/gonz/serve.ex
+++ b/lib/mix/tasks/gonz/serve.ex
@@ -3,10 +3,14 @@ defmodule Mix.Tasks.Gonz.Serve do
   Starts a local web server to serve the built site
   """
 
-  def run([]), do: run(["build", "4000"])
+  @default_port "4000"
 
-  def run([build_dir, port_str]) do
-    port = String.to_integer(port_str)
+  def run([]), do: run(["build", @default_port])
+
+  def run([build_dir]), do: run([build_dir, @default_port])
+
+  def run([build_dir, port_input]) do
+    port = String.to_integer(port_input)
     Application.start(:cowboy)
     Application.start(:plug)
     IO.puts("Starting web server. Site at http://localhost:#{port}/ serving files from dir: #{build_dir}")

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Gonz.MixProject do
   def project do
     [
       app: :gonz,
-      version: "3.0.0",
+      version: "3.1.0",
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/mix.lock
+++ b/mix.lock
@@ -6,7 +6,7 @@
   "makeup": {:hex, :makeup, "1.0.0", "671df94cf5a594b739ce03b0d0316aa64312cee2574b6a44becb83cd90fb05dc", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.14.0", "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
   "mime": {:hex, :mime, "1.3.1", "30ce04ab3175b6ad0bdce0035cba77bba68b813d523d1aac73d9781b4d193cf8", [:mix], [], "hexpm"},
-  "nimble_parsec": {:hex, :nimble_parsec, "0.5.1", "c90796ecee0289dbb5ad16d3ad06f957b0cd1199769641c961cfe0b97db190e0", [], [], "hexpm"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.5.1", "c90796ecee0289dbb5ad16d3ad06f957b0cd1199769641c961cfe0b97db190e0", [:mix], [], "hexpm"},
   "plug": {:hex, :plug, "1.8.3", "12d5f9796dc72e8ac9614e94bda5e51c4c028d0d428e9297650d09e15a684478", [:mix], [{:mime, "~> 1.0", [hex: :mime, repo: "hexpm", optional: false]}, {:plug_crypto, "~> 1.0", [hex: :plug_crypto, repo: "hexpm", optional: false]}, {:telemetry, "~> 0.4", [hex: :telemetry, repo: "hexpm", optional: true]}], "hexpm"},
   "plug_crypto": {:hex, :plug_crypto, "1.0.0", "18e49317d3fa343f24620ed22795ec29d4a5e602d52d1513ccea0b07d8ea7d4d", [:mix], [], "hexpm"},
   "ranch": {:hex, :ranch, "1.7.1", "6b1fab51b49196860b733a49c07604465a47bdb78aa10c1c16a3d199f7f8c881", [:rebar3], [], "hexpm"},


### PR DESCRIPTION
This allows users to decide on how many posts
should be visible on the index page before
starting the pagination.

Default is set to 10.